### PR TITLE
preferRelative has been deleted

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -21,7 +21,6 @@ const config: webpack.Configuration = {
     },
     resolve: {
         extensions: ['.tsx', '.ts', '.js'],
-        preferRelative: true,
     },
     plugins: [
         new HtmlWebpackPlugin({


### PR DESCRIPTION
There has been an error in reason of incorrect npm packages versions. So, I've added the preferRelative to webpack. It is unnessasury after npm packages updating
