### PR TITLE
dev server, npm scripts + env, build modes

### DIFF
--- a/config/build/buildDevServer.ts
+++ b/config/build/buildDevServer.ts
@@ -1,0 +1,9 @@
+import {IBuildOptions} from "./types/config";
+import {Configuration as DevServerConfiguration} from "webpack-dev-server";
+
+export function buildDevServer(options: IBuildOptions): DevServerConfiguration {
+    return {
+        open: true,
+        port: options.port,
+    }
+}

--- a/config/build/buildWebpackConfig.ts
+++ b/config/build/buildWebpackConfig.ts
@@ -3,12 +3,13 @@ import webpack from "webpack";
 import {buildLoaders} from "./buildLoaders";
 import {buildResolvers} from "./buildResolvers";
 import {buildPlugins} from "./buildPlugins";
+import {buildDevServer} from "./buildDevServer";
 
 export function buildWebpackConfig(options: IBuildOptions): webpack.Configuration {
-    const {mode, paths} = options
+    const {mode, paths, isDev} = options
 
     return {
-        mode: mode,
+        mode,
         entry: paths.entry,
         output: {
             filename: "[name].[contenthash].js",
@@ -20,5 +21,7 @@ export function buildWebpackConfig(options: IBuildOptions): webpack.Configuratio
         },
         resolve: buildResolvers(),
         plugins: buildPlugins(options),
+        devtool: isDev ? 'inline-source-map' : undefined,
+        devServer: isDev? buildDevServer(options) : undefined,
     }
 }

--- a/config/build/types/config.ts
+++ b/config/build/types/config.ts
@@ -8,4 +8,10 @@ export interface IBuildOptions {
     mode: BuildMode;
     paths: IBuildPaths;
     isDev: boolean;
+    port: number
+}
+
+export interface IBuildMode {
+    mode: BuildMode,
+    port: number
 }

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,10 +1,1 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-<script defer src="main.1cb00adc16b716875fbe.js"></script></head>
-<body>
-<div class="root"></div>
-</body>
-</html>
+<!doctype html><html lang="en"><head><meta charset="UTF-8"><title>Title</title><script defer="defer" src="main.b9a2a01046d12dda90c6.js"></script></head><body><div class="root"></div></body></html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.ts",
   "scripts": {
-    "build": "webpack"
+    "start": "webpack serve --env port=3000",
+    "build:prod": "webpack --env mode=production",
+    "build:dev": "webpack --env mode=development"
   },
   "keywords": [],
   "author": "",
@@ -12,11 +14,13 @@
   "devDependencies": {
     "@types/node": "^17.0.21",
     "@types/webpack": "^5.28.0",
+    "@types/webpack-dev-server": "^4.7.2",
     "html-webpack-plugin": "^5.5.0",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.5.0",
     "typescript": "^4.5.5",
     "webpack": "^5.69.1",
-    "webpack-cli": "^4.9.2"
+    "webpack-cli": "^4.9.2",
+    "webpack-dev-server": "^4.11.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 import {someFn} from './test'
 
-someFn(123)
+someFn(1233)

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,5 +1,5 @@
 export function someFn(arg: number): string {
-    console.log('RANDOM FUNCTION')
+    console.log('RANDOM FUNCTION' + arg)
 
     return ''
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,21 +1,25 @@
 import path from 'path';
 import webpack from 'webpack';
 import {buildWebpackConfig} from "./config/build/buildWebpackConfig";
-import {IBuildPaths} from "./config/build/types/config";
+import {IBuildMode, IBuildPaths} from "./config/build/types/config";
 
-const paths: IBuildPaths = {
-    entry: path.resolve(__dirname, 'src', 'index.ts'),
-    output: path.resolve(__dirname, 'dist'),
-    html: path.resolve(__dirname, 'public', 'index.html'),
+export default (env: IBuildMode):webpack.Configuration => {
+    const paths: IBuildPaths = {
+        entry: path.resolve(__dirname, 'src', 'index.ts'),
+        output: path.resolve(__dirname, 'dist'),
+        html: path.resolve(__dirname, 'public', 'index.html'),
+    }
+
+    const mode = env.mode || 'development';
+    const isDev = mode === 'development';
+    const PORT = env.port || undefined;
+
+    const config: webpack.Configuration = buildWebpackConfig({
+        mode,
+        paths,
+        isDev,
+        port: PORT,
+    })
+
+    return config
 }
-
-const mode = 'development';
-const isDev = mode === 'development';
-
-const config: webpack.Configuration = buildWebpackConfig({
-    mode: 'development',
-    paths,
-    isDev
-})
-
-export default config


### PR DESCRIPTION
1. webpack-dev-server has been added.
2. webpack-dev-server config has been integrated to main webpack config
3. start, build:dev and build:prod scripts + env flags
4. webpack config uses env variables now